### PR TITLE
Ignore invalid battery.

### DIFF
--- a/fdpowermon
+++ b/fdpowermon
@@ -422,6 +422,9 @@ sub checklevels {
 	open my $acpi, "acpi -bi |";
 	while ($acpi_output = <$acpi>) {
 		chomp $acpi_output;
+		if ($acpi_output =~ /rate information unavailable/) {
+			next;
+		}
 		if ($acpi_output =~ /^Battery (\d): ((Dis|Not )?[Cc]harging|Unknown|Full), ((\d)+)%(, ([\d:]*))?/) {
 			$title_text .= ($found ? "\n" : "") . $acpi_output;
 			$bat = $1;


### PR DESCRIPTION
I have bluetooth mouse, which reports its battery state.

In acpi report it looks like this

```
$ acpi -bi
Battery 0: Full, 100%
Battery 0: design capacity 4473 mAh, last full capacity 1452 mAh = 32%
Battery 1: Discharging, 0%, rate information unavailable
```

In fdpowrmon tooltip I get this

![image](https://user-images.githubusercontent.com/3152421/189227268-577b2ae2-2f08-4841-9202-b138e02f5630.png)

And icon

![Снимок экрана в 2022-09-09 00-12-42](https://user-images.githubusercontent.com/3152421/189227459-30e0a07f-bab7-4ebd-8d47-5f48b2e6502c.png)

As is acpi never reports correct state - I never see correct icon (charging/discharging/percent).

This PR add code to skip batteries without rate information.